### PR TITLE
Fix: dstack _push does not assign new_cap

### DIFF
--- a/source/base/ds.h
+++ b/source/base/ds.h
@@ -109,6 +109,7 @@ void* prev = stack->elems;\
 u32 new_cap = DoubleCapacity(stack->cap);\
 stack->elems = calloc(new_cap, sizeof(Data));\
 memmove(stack->elems, prev, stack->len * sizeof(Data));\
+stack->cap = new_cap;\
 free(prev);\
 }\
 stack->elems[stack->len++] = data;\


### PR DESCRIPTION
Hi! 

Not sure if your open to pull requests but since i'm taking inspiration
from your code (aswell as mr 4th programmer) i felt a pull request for a bug i noticed
would be appropriate.

Seems that the current implementation of dstack_push does not assign the new re-sized capacity
making it always trigger the if and cause the calloc flow to trigger.

Thanks for publishing your code for others to take inspiration from and happy coding!

Kind Regards,
DrNotThatEvil